### PR TITLE
Adding decode_uri to reverse Rison's _distinctive_ encode_uri method

### DIFF
--- a/js/rison.js
+++ b/js/rison.js
@@ -252,6 +252,15 @@ rison.quote = function(x) {
         return rison.quote(s[typeof v](v));
     };
 
+    /**
+     * uri-decode (reversing encode_uri's space -> '+' mapping) then rison-decode a string
+     * Reverses encode_uri
+     *
+     */
+    rison.decode_uri = function (str) {
+        return rison.decode(decodeURIComponent(str.replace(/\+/g,'%20')));
+    };
+
 })();
 
 

--- a/tests/06-roundtrip.js
+++ b/tests/06-roundtrip.js
@@ -1,0 +1,11 @@
+var test = require('tape');
+var rison = require('../');
+
+test('characters should roundtrip through encode_uri/decode_uri', function(t) {
+  t.plan(1);
+
+  var originalObject = {" &+~!*()-_.'\",:@$/":" &+~!*()-_.'\",:@$/"}
+  var encodeThenDecode = rison.decode_uri(rison.encode_uri(originalObject));
+  t.deepEqual(encodeThenDecode, originalObject, 'obj -> encode -> decode = obj');
+
+});


### PR DESCRIPTION
The non-existence of any function (or pair of functions) in Rison or vanilla JS that can reverse rison.encode_uri was a bit unfortunate, as I first reported in https://github.com/Nanonid/rison/issues/26

Now that I found a fork that seems to be maintained, I thought I would contribute the missing method, rison.decode_uri