### PR TITLE
Fixed parsing object bug where key such as 1m is treated as number, b…

### DIFF
--- a/js/rison.js
+++ b/js/rison.js
@@ -189,7 +189,7 @@ rison.unquote = function (s) {
                             if (b) {
                                 a[a.length] = ',';
                             }
-                            k = isNaN(parseInt(i)) ? s.string(i) : s.number(i)
+                            k = !isFinite(i) || isNaN(parseInt(i)) ? s.string(i) : s.number(i)
                             a.push(k, ':', v);
                             b = true;
                         }

--- a/tests/01-basic.js
+++ b/tests/01-basic.js
@@ -29,6 +29,42 @@ test('basic object encoding', function(t) {
   );
 });
 
+test('object with alpha key encoding', function(t) {
+  t.plan(2);
+
+  var decoded = { '1m': 'odd(characters:)' };
+  var encoded = "('1m':'odd(characters:)')";
+
+  t.equal(
+    rison.encode(decoded),
+    encoded,
+    'encodes object with url unsafe characters'
+  );
+  t.deepEqual(
+    rison.decode(encoded),
+    decoded,
+    'decodes object with url unsafe characters'
+  );
+});
+
+test('object with number key encoding', function(t) {
+  t.plan(2);
+
+  var decoded = { 1: 'odd(characters:)' };
+  var encoded = "(1:'odd(characters:)')";
+
+  t.equal(
+    rison.encode(decoded),
+    encoded,
+    'encodes object with url unsafe characters'
+  );
+  t.deepEqual(
+    rison.decode(encoded),
+    decoded,
+    'decodes object with url unsafe characters'
+  );
+});
+
 test('basic number encoding, prop is not quoted', function(t) {
   t.plan(3);
 


### PR DESCRIPTION
…ut when it converts to number, !n is returned.

Test:
var rison = require('rison-node');
rison.encode({ "1m": "value1", "1wk": "value2" });

Current output:
(!n:value1,!n:value2)

Should be:
('1m':value1,'1wk':value2)